### PR TITLE
Fixed award image size to match instructions

### DIFF
--- a/plugins/awards/src/components/AwardEditComponent/AwardEditComponent.tsx
+++ b/plugins/awards/src/components/AwardEditComponent/AwardEditComponent.tsx
@@ -231,7 +231,7 @@ export const AwardEditCard = ({ award = emptyAward }: AwardEditCardProps) => {
               <InputLabel>Award logo (150x50 px)</InputLabel>
             </Grid>
             <Grid item>
-              <img alt="" src={awardImage} height="50" width="100" />
+              <img alt="" src={awardImage} height="50" width="150" />
             </Grid>
             <Grid item>
               <Button

--- a/plugins/awards/src/components/AwardsListComponent/AwardsListComponent.tsx
+++ b/plugins/awards/src/components/AwardsListComponent/AwardsListComponent.tsx
@@ -66,7 +66,7 @@ export const DenseTable = ({ awards, title, edit }: DenseTableProps) => {
         <Link to={`/awards/${action}/${award.uid}`}>
           <Box alignItems="center" display="flex" flexDirection="column">
             <Box>
-              <img alt="" src={award.image} height="50" width="100" />
+              <img alt="" src={award.image} height="50" width="150" />
             </Box>
             <Box sx={{ width: '100%', textAlign: 'center' }}>{award.name}</Box>
           </Box>

--- a/plugins/awards/src/components/Cards/User/UserAwardsCard/UserAwardsCard.tsx
+++ b/plugins/awards/src/components/Cards/User/UserAwardsCard/UserAwardsCard.tsx
@@ -67,14 +67,11 @@ export const UserAwardsCard = () => {
                       <img
                         src={award.image}
                         height="50"
-                        width="100"
+                        width="150"
                         alt={award.name}
                       />
                     </Tooltip>
                   </Box>
-                  {/* <Box sx={{ width: '100%', textAlign: 'center' }}>
-                        {award.name}
-                      </Box> */}
                 </Box>
               </Link>
             </Grid>


### PR DESCRIPTION
The instructions clearly say images should be 150x50px in size, however, all widgets display them as 100x50px. Now this is fixed.