### PR TITLE
refactor: use application object for awards backend

### DIFF
--- a/plugins/awards-backend/src/awards.ts
+++ b/plugins/awards-backend/src/awards.ts
@@ -14,13 +14,7 @@ export class Awards {
   }
 
   async update(identityRef: string, uid: string, input: AwardInput): Promise<Award> {
-    const res = await this.db.search(uid, '', [], []);
-
-    if (!res || res.length === 0) {
-      throw new NotFoundError(uid);
-    }
-
-    const award: Award = res[0];
+    const award = await this.getAwardByUid(uid);
 
     if (!award.owners.includes(identityRef)) {
       throw new Error('Unauthorized to update award');
@@ -39,18 +33,22 @@ export class Awards {
   }
 
   async delete(identityRef: string, uid: string): Promise<boolean> {
-    const res = await this.db.search(uid, '', [], []);
-
-    if (!res || res.length === 0) {
-      throw new NotFoundError(uid);
-    }
-
-    const award: Award = res[0];
+    const award = await this.getAwardByUid(uid);
 
     if (!award.owners.includes(identityRef)) {
       throw new Error('Unauthorized to delete award');
     }
 
     return await this.db.delete(uid);
+  }
+
+  private async getAwardByUid(uid: string): Promise<Award> {
+    const res = await this.db.search(uid, '', [], []);
+
+    if (!res || res.length === 0) {
+      throw new NotFoundError(uid);
+    }
+
+    return res[0];
   }
 }

--- a/plugins/awards-backend/src/awards.ts
+++ b/plugins/awards-backend/src/awards.ts
@@ -2,10 +2,10 @@
  * Copyright SeatGeek
  * Licensed under the terms of the Apache-2.0 license. See LICENSE file in project root for terms.
  */
-import { Award, AwardInput } from "@seatgeek/backstage-plugin-awards-common";
-import { AwardsStore } from "./database/awards";
-import { NotFoundError } from "@backstage/errors";
-import { Logger } from "winston";
+import { NotFoundError } from '@backstage/errors';
+import { Award, AwardInput } from '@seatgeek/backstage-plugin-awards-common';
+import { Logger } from 'winston';
+import { AwardsStore } from './database/awards';
 
 export class Awards {
   private readonly db: AwardsStore;
@@ -31,7 +31,11 @@ export class Awards {
     );
   }
 
-  async update(identityRef: string, uid: string, input: AwardInput): Promise<Award> {
+  async update(
+    identityRef: string,
+    uid: string,
+    input: AwardInput,
+  ): Promise<Award> {
     const award = await this.getAwardByUid(uid);
 
     if (!award.owners.includes(identityRef)) {

--- a/plugins/awards-backend/src/awards.ts
+++ b/plugins/awards-backend/src/awards.ts
@@ -1,0 +1,40 @@
+import { Award, AwardInput } from "@seatgeek/backstage-plugin-awards-common";
+import { AwardsStore } from "./database/awards";
+import { NotFoundError } from "@backstage/errors";
+import { Logger } from "winston";
+
+export class Awards {
+  private readonly db: AwardsStore;
+  private readonly logger: Logger;
+
+  constructor(db: AwardsStore, logger: Logger) {
+    this.db = db;
+    this.logger = logger.child({ class: 'Awards' });
+    this.logger.debug('Constructed');
+  }
+
+  async update(identityRef: string, uid: string, input: AwardInput): Promise<Award> {
+    const res = await this.db.search(uid, '', [], []);
+
+    if (!res || res.length === 0) {
+      throw new NotFoundError(uid);
+    }
+
+    const award: Award = res[0];
+
+    if (!award.owners.includes(identityRef)) {
+      throw new Error('Unauthorized to update award');
+    }
+
+    const updated = await this.db.update(
+      uid,
+      input.name,
+      input.description,
+      input.image,
+      input.owners,
+      input.recipients,
+    );
+
+    return updated;
+  }
+}

--- a/plugins/awards-backend/src/awards.ts
+++ b/plugins/awards-backend/src/awards.ts
@@ -13,6 +13,10 @@ export class Awards {
     this.logger.debug('Constructed');
   }
 
+  async get(uid: string): Promise<Award> {
+    return await this.getAwardByUid(uid);
+  }
+
   async update(identityRef: string, uid: string, input: AwardInput): Promise<Award> {
     const award = await this.getAwardByUid(uid);
 

--- a/plugins/awards-backend/src/awards.ts
+++ b/plugins/awards-backend/src/awards.ts
@@ -37,4 +37,20 @@ export class Awards {
 
     return updated;
   }
+
+  async delete(identityRef: string, uid: string): Promise<boolean> {
+    const res = await this.db.search(uid, '', [], []);
+
+    if (!res || res.length === 0) {
+      throw new NotFoundError(uid);
+    }
+
+    const award: Award = res[0];
+
+    if (!award.owners.includes(identityRef)) {
+      throw new Error('Unauthorized to delete award');
+    }
+
+    return await this.db.delete(uid);
+  }
 }

--- a/plugins/awards-backend/src/awards.ts
+++ b/plugins/awards-backend/src/awards.ts
@@ -1,3 +1,7 @@
+/*
+ * Copyright SeatGeek
+ * Licensed under the terms of the Apache-2.0 license. See LICENSE file in project root for terms.
+ */
 import { Award, AwardInput } from "@seatgeek/backstage-plugin-awards-common";
 import { AwardsStore } from "./database/awards";
 import { NotFoundError } from "@backstage/errors";

--- a/plugins/awards-backend/src/awards.ts
+++ b/plugins/awards-backend/src/awards.ts
@@ -17,6 +17,16 @@ export class Awards {
     return await this.getAwardByUid(uid);
   }
 
+  async create(input: AwardInput): Promise<Award> {
+    return await this.db.add(
+      input.name,
+      input.description,
+      input.image,
+      input.owners,
+      input.recipients,
+    );
+  }
+
   async update(identityRef: string, uid: string, input: AwardInput): Promise<Award> {
     const award = await this.getAwardByUid(uid);
 

--- a/plugins/awards-backend/src/service/router.ts
+++ b/plugins/awards-backend/src/service/router.ts
@@ -8,8 +8,8 @@ import { IdentityApi } from '@backstage/plugin-auth-node';
 import express from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';
-import { DatabaseAwardsStore } from '../database/awards';
 import { Awards } from '../awards';
+import { DatabaseAwardsStore } from '../database/awards';
 
 export interface RouterOptions {
   identity: IdentityApi;

--- a/plugins/awards-backend/src/service/router.ts
+++ b/plugins/awards-backend/src/service/router.ts
@@ -94,7 +94,7 @@ export async function createRouter(
     // TODO: validate uuid parameter
     // TODO: validate request.body
 
-    const upd = awardsApp.update(userRef, uid, request.body);
+    const upd = await awardsApp.update(userRef, uid, request.body);
 
     response.json(upd);
   });

--- a/plugins/awards-backend/src/service/router.ts
+++ b/plugins/awards-backend/src/service/router.ts
@@ -110,17 +110,9 @@ export async function createRouter(
     // Just to protect the request
     await getUserRef(identity, request);
 
-    const { name, description, image, owners, recipients } = request.body;
+    const award = await awardsApp.create(request.body);
 
-    const resp = await dbStore.add(
-      name,
-      description,
-      image,
-      owners,
-      recipients,
-    );
-
-    response.json(resp);
+    response.json(award);
   });
 
   router.use(errorHandler());

--- a/plugins/awards-backend/src/service/router.ts
+++ b/plugins/awards-backend/src/service/router.ts
@@ -3,9 +3,8 @@
  * Licensed under the terms of the Apache-2.0 license. See LICENSE file in project root for terms.
  */
 import { PluginDatabaseManager, errorHandler } from '@backstage/backend-common';
-import { AuthenticationError, NotFoundError } from '@backstage/errors';
+import { AuthenticationError } from '@backstage/errors';
 import { IdentityApi } from '@backstage/plugin-auth-node';
-import { Award } from '@seatgeek/backstage-plugin-awards-common';
 import express from 'express';
 import Router from 'express-promise-router';
 import { Logger } from 'winston';

--- a/plugins/awards-backend/src/service/router.ts
+++ b/plugins/awards-backend/src/service/router.ts
@@ -78,13 +78,9 @@ export async function createRouter(
 
     const uid = request.params.uid;
     // TODO: validate uuid parameter
-    const resp = await dbStore.search(uid, '', [], []);
 
-    if (!resp) {
-      throw new NotFoundError(uid);
-    }
-
-    response.json(resp);
+    const award = await awardsApp.get(uid);
+    response.json(award);
   });
 
   router.put('/:uid', async (request, response) => {

--- a/plugins/awards-backend/src/service/router.ts
+++ b/plugins/awards-backend/src/service/router.ts
@@ -105,19 +105,9 @@ export async function createRouter(
     const uid = request.params.uid;
     // TODO: validate uuid parameter
 
-    const res = await dbStore.search(uid, '', [], []);
+    const result = await awardsApp.delete(userRef, uid);
 
-    if (!res || res.length === 0) {
-      throw new NotFoundError(uid);
-    }
-
-    const award: Award = res[0];
-
-    if (!award.owners.includes(userRef)) {
-      throw new Error('Unauthorized to delete award');
-    }
-
-    response.json(dbStore.delete(uid));
+    response.json(result);
   });
 
   router.post('/', async (request, response) => {

--- a/plugins/awards-common/src/types/award.ts
+++ b/plugins/awards-common/src/types/award.ts
@@ -11,3 +11,5 @@ export interface Award {
   owners: string[];
   recipients: string[];
 }
+
+export type AwardInput = Omit<Award, 'uid'>;


### PR DESCRIPTION
before we set up slack notifications for new recipients of awards, i'd like to refactor the awards backend a bit to separate the delivery layer from the awards logic. 