### PR TITLE
feat!(awards): add GCS storage for award logos (#37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ site
 e2e-test-report/
 
 packages/backend/tmp-awards-storage
+
+# webstorm IDE
+.idea

--- a/plugins/awards-backend/README.md
+++ b/plugins/awards-backend/README.md
@@ -74,6 +74,16 @@ awards:
       directory: my-directory # optional: defaults to tmp-awards-storage
 ```
 
+### GCS
+
+```yaml
+awards:
+  storage:
+    gcs:
+      bucket: gs://backstage-awards # required
+      keyFilename: path/to/keyFile.json # optional: defaults to GOOGLE_APPLICATION_CREDENTIALS
+```
+
 ### S3
 
 ```yaml

--- a/plugins/awards-backend/package.json
+++ b/plugins/awards-backend/package.json
@@ -35,6 +35,7 @@
     "@slack/webhook": "^7.0.2",
     "@tweedegolf/sab-adapter-amazon-s3": "^1.0.13",
     "@tweedegolf/sab-adapter-local": "^1.0.5",
+    "@tweedegolf/sab-adapter-google-cloud": "^1.0.5",
     "@tweedegolf/storage-abstraction": "^2.1.1",
     "@types/express": "*",
     "@types/express-fileupload": "^1.4.4",

--- a/plugins/awards-backend/src/service/router.test.ts
+++ b/plugins/awards-backend/src/service/router.test.ts
@@ -142,6 +142,42 @@ describe('getStorageClient', () => {
       type: StorageType.S3,
     });
   });
+  it('creates a GCS storage client with key file', () => {
+    const config = new ConfigReader({
+      awards: {
+        storage: {
+          gcs: {
+            bucket: 'gs://my-bucket',
+            keyFilename: 'path/to/keyFile.json',
+          },
+        },
+      },
+    });
+
+    const storage = getStorageClient(config);
+    expect(storage.getConfig()).toEqual({
+      bucketName: 'gs://my-bucket',
+      keyFilename: 'path/to/keyFile.json',
+      type: StorageType.GCS,
+    });
+  });
+  it('creates a GCS storage client from GOOGLE_APPLICATION_CREDENTIALS', () => {
+    const config = new ConfigReader({
+      awards: {
+        storage: {
+          gcs: {
+            bucket: 'gs://my-bucket',
+          },
+        },
+      },
+    });
+
+    const storage = getStorageClient(config);
+    expect(storage.getConfig()).toEqual({
+      bucketName: 'gs://my-bucket',
+      type: StorageType.GCS,
+    });
+  });
 
   it('errors if multiple storage engines provided', () => {
     const config = new ConfigReader({
@@ -149,6 +185,7 @@ describe('getStorageClient', () => {
         storage: {
           s3: {},
           fs: {},
+          gcs: {},
         },
       },
     });

--- a/plugins/awards-backend/src/service/router.ts
+++ b/plugins/awards-backend/src/service/router.ts
@@ -65,6 +65,18 @@ function buildFsAdapter(config: Config): Storage {
   });
 }
 
+function buildGcsAdapter(config: Config): Storage {
+  // bucket name
+  const bucketName = config.getString('bucket');
+  // keyFilename
+  const keyFilename = config.getOptionalString('keyFilename');
+  return new Storage({
+    type: StorageType.GCS,
+    bucketName: bucketName,
+    keyFilename: keyFilename,
+  });
+}
+
 export function getStorageClient(config: Config): Storage {
   const storageConfig = config.getConfig('awards.storage');
   const configs: Record<string, Config> = {};
@@ -88,9 +100,11 @@ export function getStorageClient(config: Config): Storage {
       return buildS3Adapter(configs.s3);
     case 'fs':
       return buildFsAdapter(configs.fs);
+    case 'gcs':
+      return buildGcsAdapter(configs.gcs);
     default:
       throw new Error(
-        `Invalid storage engine type, valid types are "s3", "fs", got: ${key}`,
+        `Invalid storage engine type, valid types are "s3", "fs", "gcs", got: ${key}`,
       );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5346,7 +5346,7 @@
   resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-4.0.0.tgz#a906e533ebdd0f754dca2509933334ce58b8c8b1"
   integrity sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==
 
-"@google-cloud/storage@^7.0.0":
+"@google-cloud/storage@^7.0.0", "@google-cloud/storage@^7.6.0":
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/@google-cloud/storage/-/storage-7.7.0.tgz#d942ebea018386d276256bad93ceec9bdb955333"
   integrity sha512-EMCEY+6JiIkx7Dt8NXVGGjy1vRdSGdHkoqZoqjJw7cEBkT7ZkX0c7puedfn1MamnzW5SX4xoa2jVq5u7OWBmkQ==
@@ -9816,6 +9816,13 @@
   dependencies:
     "@aws-sdk/client-s3" "^3.503.1"
     "@aws-sdk/s3-request-presigner" "^3.503.1"
+
+"@tweedegolf/sab-adapter-google-cloud@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@tweedegolf/sab-adapter-google-cloud/-/sab-adapter-google-cloud-1.0.5.tgz#c80edeab4f145884eecfe6c9eb455878eccd2226"
+  integrity sha512-jA/1ySY5PaDYwFUZ9RgAsK6ObvgHZ3KWdLsRuo1IDN2SAm2LO46LD30nEF4m71gBnlnWEuScogCnUYHiCvflBQ==
+  dependencies:
+    "@google-cloud/storage" "^7.6.0"
 
 "@tweedegolf/sab-adapter-local@^1.0.5":
   version "1.0.5"


### PR DESCRIPTION
Award logos are now stored via GCS, s3 or local filesystem storage.

```yaml
awards:
  storage:
    gcs:
      bucket: gs://backstage-awards # required
      keyFilename: path/to/keyFile.json # optional: defaults to GOOGLE_APPLICATION_CREDENTIALS
```