### PR TITLE
Update README.md to Resolve Errors

### DIFF
--- a/plugins/catalog-backend-module-okta/README.md
+++ b/plugins/catalog-backend-module-okta/README.md
@@ -40,7 +40,7 @@ export default async function createPlugin(
       logger: env.logger,
       schedule: env.scheduler.createScheduledTaskRunner({
         frequency: { days: 1 },
-        timeout: { minutes: 30 },
+        timeout: { minutes: 5 },
       }),
       // query params passed to the okta api groups request
       listGroupsRequest: {

--- a/plugins/catalog-backend-module-okta/README.md
+++ b/plugins/catalog-backend-module-okta/README.md
@@ -40,6 +40,7 @@ export default async function createPlugin(
       logger: env.logger,
       schedule: env.scheduler.createScheduledTaskRunner({
         frequency: { days: 1 },
+        timeout: { minutes: 30 },
       }),
       // query params passed to the okta api groups request
       listGroupsRequest: {
@@ -67,10 +68,12 @@ export default async function createPlugin(
           name: oktaGroup.profile!.name!.toLowerCase(),
           description: oktaGroup.profile?.description || '',
         },
-        type: 'team',
-        children: [],
-        profile: {
-          displayName: oktaGroup.profile!.name!,
+        spec: {
+          type: 'team',
+          children: [],
+          profile: {
+            displayName: oktaGroup.profile!.name!,
+          },
         },
       }),
     }),


### PR DESCRIPTION
Adding an additional scheduler option as the previous example was failing to build the backend. #49 
Also, the spec was missing in the groupTransformer which caused all insertions of new groups to fail with an error such that:
```
[1] 2024-03-21T21:53:32.085Z catalog warn Policy check failed for group:default/xxxxxxxx; caused by Error: Malformed envelope, <root> must NOT have additional properties type=plugin entity=group:default/xxxxx
```