### PR TITLE
feat: allow options to be configured for hcl merge scaffolder actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['>=20.8.0']
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['>=20.8.0']
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['>=20.8.0']
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '>=20.8.0'
+          node-version: '20.x'
           cache: 'yarn'
       # failures with peer dependencies will fail release
       - run: yarn install
@@ -81,10 +81,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Use Node.js >=20.8.0
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: '>=20.8.0'
+          node-version: '20.x'
           cache: 'yarn'
       - run: yarn install
       - run: yarn tsc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '>=20.8.0'
+          node-version: '20.x'
           cache: 'yarn'
       - run: yarn install
       - run: yarn tsc

--- a/plugins/scaffolder-backend-module-hcl/package.json
+++ b/plugins/scaffolder-backend-module-hcl/package.json
@@ -29,8 +29,10 @@
   "dependencies": {
     "@backstage/backend-common": "^0.24.1",
     "@backstage/backend-plugin-api": "^0.8.1",
+    "@backstage/backend-test-utils": "^1.1.0",
     "@backstage/config": "^1.2.0",
     "@backstage/plugin-scaffolder-node": "^0.4.10",
+    "@backstage/types": "^1.2.0",
     "@seatgeek/node-hcl": "^1.0.0",
     "fs-extra": "^11.2.0",
     "zod": "^3.23.8"

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
@@ -2,19 +2,22 @@
  * Copyright SeatGeek
  * Licensed under the terms of the Apache-2.0 license. See LICENSE file in project root for terms.
  */
-import { getVoidLogger } from '@backstage/backend-common';
+import { mockServices } from '@backstage/backend-test-utils';
 import { randomBytes } from 'crypto';
 import { writeFileSync } from 'fs-extra';
 import { tmpdir } from 'os';
 import { PassThrough } from 'stream';
 import { createHclMergeAction, createHclMergeFilesAction } from './hcl';
 
-// Since we have to
 const TMP_DIR = tmpdir();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('createHclMergeAction', () => {
   const mockContext = {
-    logger: getVoidLogger(),
+    logger: mockServices.logger.mock(),
     logStream: new PassThrough(),
     output: jest.fn(),
     createTemporaryDirectory: jest.fn(),
@@ -29,18 +32,30 @@ describe('createHclMergeAction', () => {
       description = "Name to be used on all the resources as identifier"
       type        = string
       default     = ""
+
+      map = {
+        foo = "bar"
+      }
     }`;
 
     const b = `
     variable "name" {
       type        = string
       default     = "my-name"
+
+      map = {
+        bar = "baz"
+      }
     }`;
 
+    // with mergeMapKeys set to false, the map will be overridden
     const expected = `variable "name" {
   default     = "my-name"
   description = "Name to be used on all the resources as identifier"
-  type        = string
+  map = {
+    bar = "baz"
+  }
+  type = string
 }
 
 `;
@@ -50,9 +65,62 @@ describe('createHclMergeAction', () => {
       input: {
         aSourceContent: a,
         bSourceContent: b,
+        options: {
+          mergeMapKeys: false,
+        },
       },
     };
 
+    // @ts-expect-error
+    await createHclMergeAction().handler(mockCtx);
+
+    expect(mockCtx.output.mock.calls[0][0]).toEqual('hcl');
+    expect(mockCtx.output.mock.calls[0][1]).toEqual(expected);
+  });
+
+  it('should merge HCL files with mergeMapKeys set to true', async () => {
+    const a = `
+    variable "name" {
+      type        = string
+
+      map1 = {
+        foo = "bar"
+      }
+    }`;
+
+    const b = `
+    variable "name" {
+      default     = "my-name"
+
+      map1 = {
+        bar = "baz"
+      }
+    }`;
+
+    // with mergeMapKeys set to true, the map will be merged
+    const expected = `variable "name" {
+  default = "my-name"
+  map1 = {
+    bar = "baz"
+    foo = "bar"
+  }
+  type = string
+}
+
+`;
+  
+    const mockCtx = {
+      ...mockContext,
+      input: {
+        aSourceContent: a,
+        bSourceContent: b,
+        options: {
+          mergeMapKeys: true,
+        },
+      },
+    };
+
+    // @ts-expect-error
     await createHclMergeAction().handler(mockCtx);
 
     expect(mockCtx.output.mock.calls[0][0]).toEqual('hcl');
@@ -62,7 +130,7 @@ describe('createHclMergeAction', () => {
 
 describe('createHclMergeFilesAction', () => {
   const mockContext = {
-    logger: getVoidLogger(),
+    logger: mockServices.logger.mock(),
     logStream: new PassThrough(),
     output: jest.fn(),
     createTemporaryDirectory: jest.fn(),
@@ -108,9 +176,13 @@ describe('createHclMergeFilesAction', () => {
       input: {
         aSourcePath: aPath,
         bSourcePath: bPath,
+        options: {
+          mergeMapKeys: false,
+        },
       },
     };
 
+    // @ts-expect-error
     await createHclMergeFilesAction().handler(mockCtx);
 
     expect(mockCtx.output.mock.calls[0][0]).toEqual('hcl');

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
@@ -108,7 +108,7 @@ describe('createHclMergeAction', () => {
 }
 
 `;
-  
+
     const mockCtx = {
       ...mockContext,
       input: {

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
@@ -3,9 +3,12 @@
  * Licensed under the terms of the Apache-2.0 license. See LICENSE file in project root for terms.
  */
 import { resolveSafeChildPath } from '@backstage/backend-plugin-api';
+import {
+  TemplateAction,
+  createTemplateAction,
+} from '@backstage/plugin-scaffolder-node';
 import { JsonObject, JsonValue } from '@backstage/types';
-import { createTemplateAction, TemplateAction } from '@backstage/plugin-scaffolder-node';
-import { merge, MergeOptions } from '@seatgeek/node-hcl';
+import { MergeOptions, merge } from '@seatgeek/node-hcl';
 
 import { ensureDirSync, readFileSync, writeFileSync } from 'fs-extra';
 import { dirname } from 'path';
@@ -42,7 +45,11 @@ async function mergeWrite(
   }
 }
 
-async function mergeFiles(aPath: string, bPath: string, options: MergeOptions): Promise<string> {
+async function mergeFiles(
+  aPath: string,
+  bPath: string,
+  options: MergeOptions,
+): Promise<string> {
   const a = await readFileSafe(aPath);
   const b = await readFileSafe(bPath);
 
@@ -64,9 +71,12 @@ async function mergeFilesWrite(
   }
 }
 
-const optionsSchema = z.object({
-  mergeMapKeys: z.boolean().optional().default(false),
-}).optional().default({ mergeMapKeys: false });
+const optionsSchema = z
+  .object({
+    mergeMapKeys: z.boolean().optional().default(false),
+  })
+  .optional()
+  .default({ mergeMapKeys: false });
 
 export const createHclMergeAction = (): TemplateAction<{
   aSourceContent: string;
@@ -172,7 +182,11 @@ export const createHclMergeFilesAction = (): TemplateAction<{
     options: optionsSchema,
   });
 
-  return createTemplateAction<{ aSourcePath: string; bSourcePath: string, options: JsonObject | undefined }>({
+  return createTemplateAction<{
+    aSourcePath: string;
+    bSourcePath: string;
+    options: JsonObject | undefined;
+  }>({
     id: 'hcl:merge:files',
     schema: {
       input: inputSchema,

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
@@ -3,8 +3,9 @@
  * Licensed under the terms of the Apache-2.0 license. See LICENSE file in project root for terms.
  */
 import { resolveSafeChildPath } from '@backstage/backend-plugin-api';
-import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
-import { merge } from '@seatgeek/node-hcl';
+import { JsonObject, JsonValue } from '@backstage/types';
+import { createTemplateAction, TemplateAction } from '@backstage/plugin-scaffolder-node';
+import { merge, MergeOptions } from '@seatgeek/node-hcl';
 
 import { ensureDirSync, readFileSync, writeFileSync } from 'fs-extra';
 import { dirname } from 'path';
@@ -29,9 +30,10 @@ async function readFileSafe(path: string): Promise<string> {
 async function mergeWrite(
   a: string,
   b: string,
+  options: MergeOptions,
   outPath: string,
 ): Promise<void> {
-  const out = await merge(a, b);
+  const out = await merge(a, b, options);
 
   try {
     await writeFileSync(outPath, out, 'utf8');
@@ -40,19 +42,20 @@ async function mergeWrite(
   }
 }
 
-async function mergeFiles(aPath: string, bPath: string): Promise<string> {
+async function mergeFiles(aPath: string, bPath: string, options: MergeOptions): Promise<string> {
   const a = await readFileSafe(aPath);
   const b = await readFileSafe(bPath);
 
-  return await merge(a, b);
+  return await merge(a, b, options);
 }
 
 async function mergeFilesWrite(
   aPath: string,
   bPath: string,
+  options: MergeOptions,
   outPath: string,
 ): Promise<void> {
-  const out = await mergeFiles(aPath, bPath);
+  const out = await mergeFiles(aPath, bPath, options);
 
   try {
     await writeFileSync(outPath, out, 'utf8');
@@ -61,15 +64,25 @@ async function mergeFilesWrite(
   }
 }
 
-export const createHclMergeAction = () => {
+const optionsSchema = z.object({
+  mergeMapKeys: z.boolean().optional().default(false),
+}).optional().default({ mergeMapKeys: false });
+
+export const createHclMergeAction = (): TemplateAction<{
+  aSourceContent: string;
+  bSourceContent: string;
+  options: JsonObject | undefined;
+}> => {
   const inputSchema = z.object({
     aSourceContent: z.string().describe('The HCL content to be merged'),
     bSourceContent: z.string().describe('The HCL content to be merged'),
+    options: optionsSchema,
   });
 
   return createTemplateAction<{
     aSourceContent: string;
     bSourceContent: string;
+    options: JsonValue | undefined;
   }>({
     id: 'hcl:merge',
     schema: {
@@ -86,19 +99,28 @@ export const createHclMergeAction = () => {
         );
       }
 
+      ctx.logger.error('output', input.data.options);
+
       const out = await merge(
         input.data.aSourceContent,
         input.data.bSourceContent,
+        input.data.options,
       );
       ctx.output('hcl', out);
     },
   });
 };
 
-export const createHclMergeWriteAction = () => {
+export const createHclMergeWriteAction = (): TemplateAction<{
+  aSourceContent: string;
+  bSourceContent: string;
+  options: JsonObject | undefined;
+  outputPath: string;
+}> => {
   const inputSchema = z.object({
     aSourceContent: z.string().describe('The HCL content to be merged'),
     bSourceContent: z.string().describe('The HCL content to be merged'),
+    options: optionsSchema,
     outputPath: z
       .string()
       .describe('The path to write the merged HCL content to'),
@@ -107,6 +129,7 @@ export const createHclMergeWriteAction = () => {
   return createTemplateAction<{
     aSourceContent: string;
     bSourceContent: string;
+    options: JsonValue | undefined;
     outputPath: string;
   }>({
     id: 'hcl:merge:write',
@@ -131,19 +154,25 @@ export const createHclMergeWriteAction = () => {
       await mergeWrite(
         input.data.aSourceContent,
         input.data.bSourceContent,
+        input.data.options,
         outPath,
       );
     },
   });
 };
 
-export const createHclMergeFilesAction = () => {
+export const createHclMergeFilesAction = (): TemplateAction<{
+  aSourcePath: string;
+  bSourcePath: string;
+  options: JsonObject | undefined;
+}> => {
   const inputSchema = z.object({
     aSourcePath: z.string().describe('The path to the HCL file to be merged'),
     bSourcePath: z.string().describe('The path to the HCL file to be merged'),
+    options: optionsSchema,
   });
 
-  return createTemplateAction<{ aSourcePath: string; bSourcePath: string }>({
+  return createTemplateAction<{ aSourcePath: string; bSourcePath: string, options: JsonObject | undefined }>({
     id: 'hcl:merge:files',
     schema: {
       input: inputSchema,
@@ -167,17 +196,24 @@ export const createHclMergeFilesAction = () => {
         ctx.workspacePath,
         input.data.bSourcePath,
       );
+      const options = input.data.options;
 
-      const out = await mergeFiles(aPath, bPath);
+      const out = await mergeFiles(aPath, bPath, options);
       ctx.output('hcl', out);
     },
   });
 };
 
-export const createHclMergeFilesWriteAction = () => {
+export const createHclMergeFilesWriteAction = (): TemplateAction<{
+  aSourcePath: string;
+  bSourcePath: string;
+  options: JsonObject | undefined;
+  outputPath: string;
+}> => {
   const inputSchema = z.object({
     aSourcePath: z.string().describe('The path to the HCL file to be merged'),
     bSourcePath: z.string().describe('The path to the HCL file to be merged'),
+    options: optionsSchema,
     outputPath: z
       .string()
       .describe('The path to write the merged HCL content to'),
@@ -186,6 +222,7 @@ export const createHclMergeFilesWriteAction = () => {
   return createTemplateAction<{
     aSourcePath: string;
     bSourcePath: string;
+    options: JsonObject | undefined;
     outputPath: string;
   }>({
     id: 'hcl:merge:files:write',
@@ -212,10 +249,11 @@ export const createHclMergeFilesWriteAction = () => {
         ctx.workspacePath,
         input.data.outputPath,
       );
+      const options = input.data.options;
 
       ensureDirSync(dirname(outPath));
 
-      await mergeFilesWrite(aPath, bPath, outPath);
+      await mergeFilesWrite(aPath, bPath, options, outPath);
     },
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3496,6 +3496,44 @@
     winston "^3.2.1"
     winston-transport "^4.5.0"
 
+"@backstage/backend-app-api@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-app-api/-/backend-app-api-1.0.2.tgz#9cf6246ea11c147dff66e3f4c79f1c233a438444"
+  integrity sha512-o3FbzKBc8Y7yWaETuN6jPRumSh+LJE+MkuqcG3aUyjI99xsgRCQwK9eNGpt3wxLSxXJgoWI4AN52SYxH8xfYvw==
+  dependencies:
+    "@backstage/backend-plugin-api" "^1.0.2"
+    "@backstage/cli-common" "^0.1.15"
+    "@backstage/config" "^1.3.0"
+    "@backstage/config-loader" "^1.9.2"
+    "@backstage/errors" "^1.2.5"
+    "@backstage/plugin-auth-node" "^0.5.4"
+    "@backstage/plugin-permission-node" "^0.8.5"
+    "@backstage/types" "^1.2.0"
+    "@manypkg/get-packages" "^1.1.3"
+    compression "^1.7.4"
+    cookie "^0.7.0"
+    cors "^2.8.5"
+    express "^4.17.1"
+    express-promise-router "^4.1.0"
+    helmet "^6.0.0"
+    jose "^5.0.0"
+    knex "^3.0.0"
+    lodash "^4.17.21"
+    logform "^2.3.2"
+    luxon "^3.0.0"
+    minimatch "^9.0.0"
+    minimist "^1.2.5"
+    morgan "^1.10.0"
+    node-fetch "^2.7.0"
+    node-forge "^1.3.1"
+    path-to-regexp "^8.0.0"
+    selfsigned "^2.0.0"
+    stoppable "^1.1.0"
+    triple-beam "^1.4.1"
+    uuid "^11.0.0"
+    winston "^3.2.1"
+    winston-transport "^4.5.0"
+
 "@backstage/backend-common@^0.24.0":
   version "0.24.0"
   resolved "https://registry.yarnpkg.com/@backstage/backend-common/-/backend-common-0.24.0.tgz#c3c6f17dc5ae909a96f5969114a17c72a4fcb234"
@@ -3635,6 +3673,76 @@
     yauzl "^3.0.0"
     yn "^4.0.0"
 
+"@backstage/backend-common@^0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-common/-/backend-common-0.25.0.tgz#11ca616cde67fe27f757a7a95817eaa3b1e33b1c"
+  integrity sha512-TMQjoZLP80ek/NYBAcFvr8p5fioxuq6rC2Qd9FHXTifTzH9k31yJqmaTUmlJcw4+tz+3h4ss3qCwGGlgfNbGfQ==
+  dependencies:
+    "@aws-sdk/abort-controller" "^3.347.0"
+    "@aws-sdk/client-codecommit" "^3.350.0"
+    "@aws-sdk/client-s3" "^3.350.0"
+    "@aws-sdk/credential-providers" "^3.350.0"
+    "@aws-sdk/types" "^3.347.0"
+    "@backstage/backend-dev-utils" "^0.1.5"
+    "@backstage/backend-plugin-api" "^1.0.0"
+    "@backstage/cli-common" "^0.1.14"
+    "@backstage/config" "^1.2.0"
+    "@backstage/config-loader" "^1.9.1"
+    "@backstage/errors" "^1.2.4"
+    "@backstage/integration" "^1.15.0"
+    "@backstage/integration-aws-node" "^0.1.12"
+    "@backstage/plugin-auth-node" "^0.5.2"
+    "@backstage/types" "^1.1.1"
+    "@google-cloud/storage" "^7.0.0"
+    "@keyv/memcache" "^1.3.5"
+    "@keyv/redis" "^2.5.3"
+    "@kubernetes/client-node" "0.20.0"
+    "@manypkg/get-packages" "^1.1.3"
+    "@octokit/rest" "^19.0.3"
+    "@types/cors" "^2.8.6"
+    "@types/dockerode" "^3.3.0"
+    "@types/express" "^4.17.6"
+    "@types/luxon" "^3.0.0"
+    "@types/webpack-env" "^1.15.2"
+    archiver "^7.0.0"
+    base64-stream "^1.0.0"
+    compression "^1.7.4"
+    concat-stream "^2.0.0"
+    cors "^2.8.5"
+    dockerode "^4.0.0"
+    express "^4.17.1"
+    express-promise-router "^4.1.0"
+    fs-extra "^11.2.0"
+    git-url-parse "^14.0.0"
+    helmet "^6.0.0"
+    isomorphic-git "^1.23.0"
+    jose "^5.0.0"
+    keyv "^4.5.2"
+    knex "^3.0.0"
+    lodash "^4.17.21"
+    logform "^2.3.2"
+    luxon "^3.0.0"
+    minimatch "^9.0.0"
+    minimist "^1.2.5"
+    morgan "^1.10.0"
+    mysql2 "^3.0.0"
+    node-fetch "^2.7.0"
+    node-forge "^1.3.1"
+    p-limit "^3.1.0"
+    path-to-regexp "^8.0.0"
+    pg "^8.11.3"
+    pg-format "^1.0.4"
+    raw-body "^2.4.1"
+    selfsigned "^2.0.0"
+    stoppable "^1.1.0"
+    tar "^6.1.12"
+    triple-beam "^1.4.1"
+    uuid "^9.0.0"
+    winston "^3.2.1"
+    winston-transport "^4.5.0"
+    yauzl "^3.0.0"
+    yn "^4.0.0"
+
 "@backstage/backend-defaults@0.4.3", "@backstage/backend-defaults@^0.4.2", "@backstage/backend-defaults@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@backstage/backend-defaults/-/backend-defaults-0.4.3.tgz#9078d176ae0fd1df77d2073286ea943c0fbfbee7"
@@ -3710,6 +3818,81 @@
     yn "^4.0.0"
     zod "^3.22.4"
 
+"@backstage/backend-defaults@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-defaults/-/backend-defaults-0.5.3.tgz#7e562d394ba4c9eac651e7b54593a4b4aefafe74"
+  integrity sha512-pzXiwywWRi8CJfUQzbVwmVcxb7mDLtKOdNE1vjfoJUK29jDLyA4+FjBy/VkndTLiCHwPbtEVQ7eKCvt48EXQeQ==
+  dependencies:
+    "@aws-sdk/abort-controller" "^3.347.0"
+    "@aws-sdk/client-codecommit" "^3.350.0"
+    "@aws-sdk/client-s3" "^3.350.0"
+    "@aws-sdk/credential-providers" "^3.350.0"
+    "@aws-sdk/types" "^3.347.0"
+    "@backstage/backend-app-api" "^1.0.2"
+    "@backstage/backend-dev-utils" "^0.1.5"
+    "@backstage/backend-plugin-api" "^1.0.2"
+    "@backstage/cli-common" "^0.1.15"
+    "@backstage/cli-node" "^0.2.10"
+    "@backstage/config" "^1.3.0"
+    "@backstage/config-loader" "^1.9.2"
+    "@backstage/errors" "^1.2.5"
+    "@backstage/integration" "^1.15.2"
+    "@backstage/integration-aws-node" "^0.1.13"
+    "@backstage/plugin-auth-node" "^0.5.4"
+    "@backstage/plugin-events-node" "^0.4.5"
+    "@backstage/plugin-permission-node" "^0.8.5"
+    "@backstage/types" "^1.2.0"
+    "@google-cloud/storage" "^7.0.0"
+    "@keyv/memcache" "^1.3.5"
+    "@keyv/redis" "^2.5.3"
+    "@manypkg/get-packages" "^1.1.3"
+    "@octokit/rest" "^19.0.3"
+    "@opentelemetry/api" "^1.3.0"
+    "@types/cors" "^2.8.6"
+    "@types/express" "^4.17.6"
+    archiver "^7.0.0"
+    base64-stream "^1.0.0"
+    better-sqlite3 "^11.0.0"
+    compression "^1.7.4"
+    concat-stream "^2.0.0"
+    cookie "^0.7.0"
+    cors "^2.8.5"
+    cron "^3.0.0"
+    express "^4.17.1"
+    express-promise-router "^4.1.0"
+    fs-extra "^11.2.0"
+    git-url-parse "^15.0.0"
+    helmet "^6.0.0"
+    isomorphic-git "^1.23.0"
+    jose "^5.0.0"
+    keyv "^4.5.2"
+    knex "^3.0.0"
+    lodash "^4.17.21"
+    logform "^2.3.2"
+    luxon "^3.0.0"
+    minimatch "^9.0.0"
+    minimist "^1.2.5"
+    morgan "^1.10.0"
+    mysql2 "^3.0.0"
+    node-fetch "^2.7.0"
+    node-forge "^1.3.1"
+    p-limit "^3.1.0"
+    path-to-regexp "^8.0.0"
+    pg "^8.11.3"
+    pg-connection-string "^2.3.0"
+    pg-format "^1.0.4"
+    raw-body "^2.4.1"
+    selfsigned "^2.0.0"
+    stoppable "^1.1.0"
+    tar "^6.1.12"
+    triple-beam "^1.4.1"
+    uuid "^11.0.0"
+    winston "^3.2.1"
+    winston-transport "^4.5.0"
+    yauzl "^3.0.0"
+    yn "^4.0.0"
+    zod "^3.22.4"
+
 "@backstage/backend-dev-utils@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@backstage/backend-dev-utils/-/backend-dev-utils-0.1.5.tgz#bee1540167df263ac82bce5a838d0387d94372d4"
@@ -3766,6 +3949,23 @@
     knex "^3.0.0"
     luxon "^3.0.0"
 
+"@backstage/backend-plugin-api@^1.0.0", "@backstage/backend-plugin-api@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-plugin-api/-/backend-plugin-api-1.0.2.tgz#d0a17dbf66e32d7d56756bc7fd6ecd0fb854f40f"
+  integrity sha512-XcTOx4ARR3JmV1y28jsi0SevQXxDF5KvOTn5D50G9XRIUnnlDMHiJjBg22kxDOZrckTlC7WWGuVe5LHnSTkcrA==
+  dependencies:
+    "@backstage/cli-common" "^0.1.15"
+    "@backstage/config" "^1.3.0"
+    "@backstage/errors" "^1.2.5"
+    "@backstage/plugin-auth-node" "^0.5.4"
+    "@backstage/plugin-permission-common" "^0.8.2"
+    "@backstage/types" "^1.2.0"
+    "@types/express" "^4.17.6"
+    "@types/luxon" "^3.0.0"
+    express "^4.17.1"
+    knex "^3.0.0"
+    luxon "^3.0.0"
+
 "@backstage/backend-tasks@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@backstage/backend-tasks/-/backend-tasks-0.6.0.tgz#088b8f4aac183998e26d4dc0f1791be077026f01"
@@ -3816,6 +4016,39 @@
     uuid "^9.0.0"
     yn "^4.0.0"
 
+"@backstage/backend-test-utils@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-test-utils/-/backend-test-utils-1.1.0.tgz#b0590fe792b0f0d415dc428d37199e7febf1ccc9"
+  integrity sha512-C5dhwgUSDPoPb26196ynoNS/BOWfUMzJIorAahqjpr52c9Gh77r+9bPddkRXQlosLFPZFvhIvAl6nGFA8G6jVw==
+  dependencies:
+    "@backstage/backend-app-api" "^1.0.2"
+    "@backstage/backend-defaults" "^0.5.3"
+    "@backstage/backend-plugin-api" "^1.0.2"
+    "@backstage/config" "^1.3.0"
+    "@backstage/errors" "^1.2.5"
+    "@backstage/plugin-auth-node" "^0.5.4"
+    "@backstage/plugin-events-node" "^0.4.5"
+    "@backstage/types" "^1.2.0"
+    "@keyv/memcache" "^1.3.5"
+    "@keyv/redis" "^2.5.3"
+    "@types/express" "^4.17.6"
+    "@types/express-serve-static-core" "^4.17.5"
+    "@types/keyv" "^4.2.0"
+    "@types/qs" "^6.9.6"
+    better-sqlite3 "^11.0.0"
+    cookie "^0.7.0"
+    express "^4.17.1"
+    fs-extra "^11.0.0"
+    keyv "^4.5.2"
+    knex "^3.0.0"
+    mysql2 "^3.0.0"
+    pg "^8.11.3"
+    pg-connection-string "^2.3.0"
+    testcontainers "^10.0.0"
+    textextensions "^5.16.0"
+    uuid "^11.0.0"
+    yn "^4.0.0"
+
 "@backstage/catalog-client@^1.6.6":
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/@backstage/catalog-client/-/catalog-client-1.6.6.tgz#365e042d526ee6f28693a72eba597e29665f326a"
@@ -3823,6 +4056,16 @@
   dependencies:
     "@backstage/catalog-model" "^1.6.0"
     "@backstage/errors" "^1.2.4"
+    cross-fetch "^4.0.0"
+    uri-template "^2.0.0"
+
+"@backstage/catalog-client@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@backstage/catalog-client/-/catalog-client-1.8.0.tgz#a618569abc552cadade18e29ce24e57ed0502fdc"
+  integrity sha512-+0DPzVwkJCTxY28VvUH7yg2087/JSyGZ7iHHShI40HAbsCitd5woJnmYa+2O1B8PuJxFbAYoZesh4uARp58NKg==
+  dependencies:
+    "@backstage/catalog-model" "^1.7.1"
+    "@backstage/errors" "^1.2.5"
     cross-fetch "^4.0.0"
     uri-template "^2.0.0"
 
@@ -3836,10 +4079,39 @@
     ajv "^8.10.0"
     lodash "^4.17.21"
 
+"@backstage/catalog-model@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@backstage/catalog-model/-/catalog-model-1.7.1.tgz#ac158f9e66f559614ea5546f01a66bb03090663b"
+  integrity sha512-TdtcpMzMMcSXlmJylEG2KbEHwxhd9XkxnvUFPKaF35Q6PjV9MhERw4qBSrINCzaIU5zn8baiyQBbg6j93r+kyA==
+  dependencies:
+    "@backstage/errors" "^1.2.5"
+    "@backstage/types" "^1.2.0"
+    ajv "^8.10.0"
+    lodash "^4.17.21"
+
 "@backstage/cli-common@^0.1.14":
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/@backstage/cli-common/-/cli-common-0.1.14.tgz#2291520acfbac860a05dd48fc3b876d5cd789b76"
   integrity sha512-4kGWGrFuxoaCne2aHCOVW+vi8y2MLEMEj785SEApMG2J8jXJXUuIOzWw0MrN0pM1FqBXDb6aeQd+bmQMK/Ci+w==
+
+"@backstage/cli-common@^0.1.15":
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/@backstage/cli-common/-/cli-common-0.1.15.tgz#20ea69cdee5025bdbdba38492ec174b1d8d470e3"
+  integrity sha512-z+jMq5h+J1ruZ0IC610QFfSQxLk3IGSL1pZ/xnEIbyohaak+eeOZCyNzKBLwQrBDnIFCdmMoq69/Vrejo2hPeA==
+
+"@backstage/cli-node@^0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@backstage/cli-node/-/cli-node-0.2.10.tgz#eb8b353afdb6cdf3e5252c8aa0bdc2dd7e41edd3"
+  integrity sha512-dVsAR1dHr86PVC24+t1mTfzs6mWFjDAKHPPucDFGl9UK4ziO9n2x0HrLsp1t12AnHI4kTEdH66UgX54y+6F3Ag==
+  dependencies:
+    "@backstage/cli-common" "^0.1.15"
+    "@backstage/errors" "^1.2.5"
+    "@backstage/types" "^1.2.0"
+    "@manypkg/get-packages" "^1.1.3"
+    "@yarnpkg/parsers" "^3.0.0"
+    fs-extra "^11.2.0"
+    semver "^7.5.3"
+    zod "^3.22.4"
 
 "@backstage/cli-node@^0.2.7":
   version "0.2.7"
@@ -3995,6 +4267,28 @@
     typescript-json-schema "^0.63.0"
     yaml "^2.0.0"
 
+"@backstage/config-loader@^1.9.1", "@backstage/config-loader@^1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@backstage/config-loader/-/config-loader-1.9.2.tgz#eac7f8a5ca88e9fcf2e4561ae80ed4bb26837fb9"
+  integrity sha512-RjE3FjgiKzn8ZTvFI+KjSkEPQR5/6ak1RO9bDO2EEG+UJKc6TXPTikMojeTx0ZwsIfGaXQKfKZBxhCOxelSJJQ==
+  dependencies:
+    "@backstage/cli-common" "^0.1.15"
+    "@backstage/config" "^1.3.0"
+    "@backstage/errors" "^1.2.5"
+    "@backstage/types" "^1.2.0"
+    "@types/json-schema" "^7.0.6"
+    ajv "^8.10.0"
+    chokidar "^3.5.2"
+    fs-extra "^11.2.0"
+    json-schema "^0.4.0"
+    json-schema-merge-allof "^0.8.1"
+    json-schema-traverse "^1.0.0"
+    lodash "^4.17.21"
+    minimist "^1.2.5"
+    node-fetch "^2.7.0"
+    typescript-json-schema "^0.65.0"
+    yaml "^2.0.0"
+
 "@backstage/config@^1.1.1", "@backstage/config@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@backstage/config/-/config-1.2.0.tgz#6a4d93197d0586ee3a40f9e4877c5cfd76c128f3"
@@ -4002,6 +4296,15 @@
   dependencies:
     "@backstage/errors" "^1.2.4"
     "@backstage/types" "^1.1.1"
+
+"@backstage/config@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@backstage/config/-/config-1.3.0.tgz#ca5771175451410bb7977e80e2b192a4dc2efd9d"
+  integrity sha512-DXrcPIwgZAHrKj3MRHt6yC63E1/LXXgM0hdAFJYkRYb7r+VX3KGBfxo1NtWdB6A4gTXhxfEWc7FWvdloIDDoGg==
+  dependencies:
+    "@backstage/errors" "^1.2.5"
+    "@backstage/types" "^1.2.0"
+    ms "^2.1.3"
 
 "@backstage/core-app-api@^1.14.2":
   version "1.14.2"
@@ -4167,6 +4470,14 @@
     "@backstage/types" "^1.1.1"
     serialize-error "^8.0.1"
 
+"@backstage/errors@^1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@backstage/errors/-/errors-1.2.5.tgz#447177ac5a5e904b5d54019f6f14eda3c1073177"
+  integrity sha512-JoLzSdCt5uHPYvC/aR/UE10+d1WlTEsR0L7xWBgcTluC9VUpFmV5W15bNL+ckZHi14nQV3V1DOk9uhsR1ER45w==
+  dependencies:
+    "@backstage/types" "^1.2.0"
+    serialize-error "^8.0.1"
+
 "@backstage/eslint-plugin@^0.1.8":
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/@backstage/eslint-plugin/-/eslint-plugin-0.1.8.tgz#4c554916ae9bdce17ab7082a5c341646f170c9b7"
@@ -4203,6 +4514,19 @@
     "@backstage/config" "^1.2.0"
     "@backstage/errors" "^1.2.4"
 
+"@backstage/integration-aws-node@^0.1.13":
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/@backstage/integration-aws-node/-/integration-aws-node-0.1.13.tgz#3dd8b6ac7efc2d0ff9313c0079b643870344b73e"
+  integrity sha512-VVReNP+BPDdnkzq9V7+KDfby+jPOIZM8S22pGiwVYCGt6cVpgOkz0M9b1ZwNQDyqnAxvlv3Yal1PaCx/XKsbWw==
+  dependencies:
+    "@aws-sdk/client-sts" "^3.350.0"
+    "@aws-sdk/credential-provider-node" "^3.350.0"
+    "@aws-sdk/credential-providers" "^3.350.0"
+    "@aws-sdk/types" "^3.347.0"
+    "@aws-sdk/util-arn-parser" "^3.310.0"
+    "@backstage/config" "^1.3.0"
+    "@backstage/errors" "^1.2.5"
+
 "@backstage/integration-react@^1.1.26", "@backstage/integration-react@^1.1.30":
   version "1.1.30"
   resolved "https://registry.yarnpkg.com/@backstage/integration-react/-/integration-react-1.1.30.tgz#71eb0e1991718527fa3917510cce7a8b4ae96b8b"
@@ -4227,6 +4551,21 @@
     "@octokit/rest" "^19.0.3"
     cross-fetch "^4.0.0"
     git-url-parse "^14.0.0"
+    lodash "^4.17.21"
+    luxon "^3.0.0"
+
+"@backstage/integration@^1.15.0", "@backstage/integration@^1.15.2":
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/@backstage/integration/-/integration-1.15.2.tgz#2f534ab8f6cc1e686654fee99770c5018acdc491"
+  integrity sha512-cCigk62u4Ikkr3J/APf0ZFpT5F7HCM/iT+hJh4n9a/ufipu945X5QfgO7odsTL5uG8YgzbU1xl25W/Z/PGuWIw==
+  dependencies:
+    "@azure/identity" "^4.0.0"
+    "@backstage/config" "^1.3.0"
+    "@backstage/errors" "^1.2.5"
+    "@octokit/auth-app" "^4.0.0"
+    "@octokit/rest" "^19.0.3"
+    cross-fetch "^4.0.0"
+    git-url-parse "^15.0.0"
     lodash "^4.17.21"
     luxon "^3.0.0"
 
@@ -4583,6 +4922,30 @@
     zod "^3.22.4"
     zod-to-json-schema "^3.21.4"
 
+"@backstage/plugin-auth-node@^0.5.2", "@backstage/plugin-auth-node@^0.5.4":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-node/-/plugin-auth-node-0.5.4.tgz#77f1bd73a25b901dc6d888fb80b7edd477f35cb8"
+  integrity sha512-XoKVmF1S9GrqdfSRsFUY9tnXB2bcuQJAVVrZzx7OUpY+O1ED/dFwAwxPtIrC1EkhoYvzM6IUCik8CR6k5fAJLA==
+  dependencies:
+    "@backstage/backend-common" "^0.25.0"
+    "@backstage/backend-plugin-api" "^1.0.2"
+    "@backstage/catalog-client" "^1.8.0"
+    "@backstage/catalog-model" "^1.7.1"
+    "@backstage/config" "^1.3.0"
+    "@backstage/errors" "^1.2.5"
+    "@backstage/types" "^1.2.0"
+    "@types/express" "*"
+    "@types/passport" "^1.0.3"
+    express "^4.17.1"
+    jose "^5.0.0"
+    lodash "^4.17.21"
+    node-fetch "^2.7.0"
+    passport "^0.7.0"
+    winston "^3.2.1"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.21.4"
+    zod-validation-error "^3.4.0"
+
 "@backstage/plugin-auth-react@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-react/-/plugin-auth-react-0.1.5.tgz#3b2e1bdbf203f98eea49dc3e6cf59ac3b520f04b"
@@ -4810,6 +5173,17 @@
   dependencies:
     "@backstage/backend-plugin-api" "^0.8.0"
 
+"@backstage/plugin-events-node@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-events-node/-/plugin-events-node-0.4.5.tgz#8fdd0d4c32cd0106d9f741ff28ca36cb7d122da0"
+  integrity sha512-Uw+JY4kPdta1HM+HkOOWzaPMiBDOji0oaCfVPVZe6drfEJnRAGn11lVIZDoinN8ua8lp26wpmVz1J4yr5oFjDA==
+  dependencies:
+    "@backstage/backend-plugin-api" "^1.0.2"
+    "@backstage/errors" "^1.2.5"
+    "@backstage/types" "^1.2.0"
+    cross-fetch "^4.0.0"
+    uri-template "^2.0.0"
+
 "@backstage/plugin-github-actions@^0.6.16":
   version "0.6.16"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-github-actions/-/plugin-github-actions-0.6.16.tgz#67b3093abf1c98ec4e6431dbf8fd442fd305326b"
@@ -4896,6 +5270,19 @@
     zod "^3.22.4"
     zod-to-json-schema "^3.20.4"
 
+"@backstage/plugin-permission-common@^0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-common/-/plugin-permission-common-0.8.2.tgz#d0e94d39f66ca2ffb5f1ba0e566b61e3bf26010c"
+  integrity sha512-rq8AMUufiFMOUeXZAJ/y1JzRpUSRFVs7ddhtsmX5nvkZP07ONT8WwnVZPYFywfX8rDt/Ym4wZuPnPk4xqHX04A==
+  dependencies:
+    "@backstage/config" "^1.3.0"
+    "@backstage/errors" "^1.2.5"
+    "@backstage/types" "^1.2.0"
+    cross-fetch "^4.0.0"
+    uuid "^11.0.0"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.20.4"
+
 "@backstage/plugin-permission-node@^0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-node/-/plugin-permission-node-0.8.1.tgz#6d4a2ca260e755af690fec3c16d93ec910c6b295"
@@ -4907,6 +5294,23 @@
     "@backstage/errors" "^1.2.4"
     "@backstage/plugin-auth-node" "^0.5.0"
     "@backstage/plugin-permission-common" "^0.8.1"
+    "@types/express" "^4.17.6"
+    express "^4.17.1"
+    express-promise-router "^4.1.0"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.20.4"
+
+"@backstage/plugin-permission-node@^0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-node/-/plugin-permission-node-0.8.5.tgz#51b73b1d580584476dd51fede729691673136848"
+  integrity sha512-fj9y5Vb2GR8/u4ejhLUrozRnk8oQBb8I4XyOW2DAYkAyKA40OJMlVHvudY+13likb6TS0ByXSuhQWYSpQbUD3g==
+  dependencies:
+    "@backstage/backend-common" "^0.25.0"
+    "@backstage/backend-plugin-api" "^1.0.2"
+    "@backstage/config" "^1.3.0"
+    "@backstage/errors" "^1.2.5"
+    "@backstage/plugin-auth-node" "^0.5.4"
+    "@backstage/plugin-permission-common" "^0.8.2"
     "@types/express" "^4.17.6"
     express "^4.17.1"
     express-promise-router "^4.1.0"
@@ -5631,6 +6035,11 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@backstage/types/-/types-1.1.1.tgz#c9ccb30357005e7fb5fa2ac140198059976eb076"
   integrity sha512-1cUGu+FwiJZCBOuecd0BOhIRkQYllb+7no9hHhxpAsx/DvsPGMVQMGOMvtdTycdT9SQ5MuSyFwI9wpXp2DwVvQ==
+
+"@backstage/types@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@backstage/types/-/types-1.2.0.tgz#14fec6240e7ec0f3189fca0890be1e54debc54ea"
+  integrity sha512-YoWvCLJNOgvRXSqH8EoWmmQ8G8+emiYpn5dqDZcMrqAA6Xa8yFFVsQTujEusx5ZSwahPMbSDobNJgiSoXL3XyA==
 
 "@backstage/version-bridge@^1.0.7", "@backstage/version-bridge@^1.0.8":
   version "1.0.8"
@@ -9187,9 +9596,9 @@
   uid ""
 
 "@seatgeek/node-hcl@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@seatgeek/node-hcl/-/node-hcl-1.0.0.tgz#817a4c2cdfa9b9cd90d2a1fa9484b32bf3412373"
-  integrity sha512-B1wmUCXcTElhD1g/IX0jYfEtOqK7vrSZ8/ZjLCWXfjxejUYRTtfxh+Ojqzz/L2KuIk0tRP6wmvbtnOIwtllviw==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@seatgeek/node-hcl/-/node-hcl-1.1.1.tgz#13e9a2127a665d8ebedeed31c28e7e4aef6033cc"
+  integrity sha512-pvqj6rzI8sG8/O62vcaj4WL4F6eQSVStGE+97GAONk1a8WLwL4yF68MXo8hfzUSsN+ljUTMoF1qnJECpHpAyLg==
   dependencies:
     fs-extra "^11.2.0"
 
@@ -12197,6 +12606,13 @@
   dependencies:
     undici-types "~5.26.4"
 
+"@types/node@^18.11.9":
+  version "18.19.64"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.64.tgz#122897fb79f2a9ec9c979bded01c11461b2b1478"
+  integrity sha512-955mDqvO2vFf/oL7V3WiUtiz+BugyX8uVbaT2H8oj3+8dRyH2FLiNdowe7eNqRM7IOIZvzDH76EoAT+gwm6aIQ==
+  dependencies:
+    undici-types "~5.26.4"
+
 "@types/normalize-package-data@^2.4.0", "@types/normalize-package-data@^2.4.1", "@types/normalize-package-data@^2.4.3":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
@@ -12254,6 +12670,11 @@
   version "6.9.11"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.11.tgz#208d8a30bc507bd82e03ada29e4732ea46a6bbda"
   integrity sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==
+
+"@types/qs@^6.9.6":
+  version "6.9.17"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.17.tgz#fc560f60946d0aeff2f914eb41679659d3310e1a"
+  integrity sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==
 
 "@types/ramda@~0.29.6":
   version "0.29.10"
@@ -13265,7 +13686,7 @@ archiver@^6.0.0:
     tar-stream "^3.0.0"
     zip-stream "^5.0.1"
 
-archiver@^7.0.1:
+archiver@^7.0.0, archiver@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/archiver/-/archiver-7.0.1.tgz#c9d91c350362040b8927379c7aa69c0655122f61"
   integrity sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==
@@ -15218,6 +15639,11 @@ cookie@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
+cookie@^0.7.0:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 cookiejar@^2.1.4:
   version "2.1.4"
@@ -18160,6 +18586,13 @@ git-url-parse@^14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-14.0.0.tgz#18ce834726d5fbca0c25a4555101aa277017418f"
   integrity sha512-NnLweV+2A4nCvn4U/m2AoYu0pPKlsmhK9cknG7IMwsjFY1S2jxM+mAhsDxyxfCIGfGaD+dozsyX4b6vkYc83yQ==
+  dependencies:
+    git-up "^7.0.0"
+
+git-url-parse@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-15.0.0.tgz#207b74d8eb888955b1aaf5dfc5f5778084fa9fa9"
+  integrity sha512-5reeBufLi+i4QD3ZFftcJs9jC26aULFLBU23FeKM/b1rI0K6ofIeAblmDVO7Ht22zTDE9+CkJ3ZVb0CgJmz3UQ==
   dependencies:
     git-up "^7.0.0"
 
@@ -22844,7 +23277,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.2:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.2, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -24676,6 +25109,11 @@ path-to-regexp@^6.2.1:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.2.tgz#324377a83e5049cbecadc5554d6a63a9a4866b36"
   integrity sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==
+
+path-to-regexp@^8.0.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.2.0.tgz#73990cc29e57a3ff2a0d914095156df5db79e8b4"
+  integrity sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -28989,6 +29427,20 @@ typescript-json-schema@^0.63.0:
     typescript "~5.1.0"
     yargs "^17.1.1"
 
+typescript-json-schema@^0.65.0:
+  version "0.65.1"
+  resolved "https://registry.yarnpkg.com/typescript-json-schema/-/typescript-json-schema-0.65.1.tgz#24840812f69b220b75d86ed87e220b3b3345db2c"
+  integrity sha512-tuGH7ff2jPaUYi6as3lHyHcKpSmXIqN7/mu50x3HlYn0EHzLpmt3nplZ7EuhUkO0eqDRc9GqWNkfjgBPIS9kxg==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@types/node" "^18.11.9"
+    glob "^7.1.7"
+    path-equal "^1.2.5"
+    safe-stable-stringify "^2.2.0"
+    ts-node "^10.9.1"
+    typescript "~5.5.0"
+    yargs "^17.1.1"
+
 "typescript@>=3 < 6":
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
@@ -29003,6 +29455,11 @@ typescript@~5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+
+typescript@~5.5.0:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
@@ -29388,6 +29845,11 @@ utils-merge@1.0.1, utils-merge@1.x.x, utils-merge@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+uuid@^11.0.0:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.3.tgz#248451cac9d1a4a4128033e765d137e2b2c49a3d"
+  integrity sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==
 
 uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
@@ -30273,6 +30735,11 @@ zod-to-json-schema@^3.20.4, zod-to-json-schema@^3.21.4:
   version "3.22.4"
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.22.4.tgz#f8cc691f6043e9084375e85fb1f76ebafe253d70"
   integrity sha512-2Ed5dJ+n/O3cU383xSY28cuVi0BCQhF8nYqWU5paEpl7fVdqdAmiLdqLyfblbNdfOFwFfi/mqU4O1pwc60iBhQ==
+
+zod-validation-error@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-3.4.0.tgz#3a8a1f55c65579822d7faa190b51336c61bee2a6"
+  integrity sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==
 
 zod@^3.22.4:
   version "3.22.4"


### PR DESCRIPTION
Implements changes included in https://github.com/seatgeek/node-hcl/pull/10 so that the merge options can be configured in the template for all hcl scaffolder actions.

```yaml
input: 
  options:
    mergeMapKeys: true # default false
```