### PR TITLE
chore: improve releasing docs and automation

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,28 @@
+name: "Lint PR Title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  validate-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure types to match semantic-release rules from package.json
+          types: >
+            feat
+            fix
+            docs
+            style
+            refactor
+            chore

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,4 +1,4 @@
-name: "Lint PR Title"
+name: 'Lint PR Title'
 
 on:
   pull_request_target:

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -16,11 +16,11 @@ Configuration is kept in [package.json](/package.json)'s `"release"` field and f
 
 ### Workflow
 
-> ⚠️ The Github Action workflow seems to be [broken](https://github.com/seatgeek/backstage-plugins/actions/runs/7730814643/job/21077039936). To release, run the same commands in [release.yml](/.github/workflows/release.yml) on your local machine, pulling `NPM_TOKEN` from the repository's secrets and a personal `GITHUB_TOKEN` with permissions listed [here](https://github.com/semantic-release/github?tab=readme-ov-file#github-authentication). Don't commit the state of your repository after the release.
-
 On all pushes to `main` we run `multi-semantic-release --dry-run` in CI to see what would be released.
 
 To actually run a release, trigger the Release workflow.
+
+(If the Release workflow is ever broken, run the same commands in [release.yml](/.github/workflows/release.yml) on your local machine, pulling `NPM_TOKEN` from the repository's secrets and a personal `GITHUB_TOKEN` with permissions listed [here](https://github.com/semantic-release/github?tab=readme-ov-file#github-authentication). Don't commit the state of your repository after the release.)
 
 ### Merging
 


### PR DESCRIPTION
1. Add a check to ensure the PR title (used as the squashed commit message) follows the Conventional Commits spec
2. Update release docs now that the expired NPM token has been replaced