### PR TITLE
feat: Upgrade node-hcl to version that supports merging tfvars files

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -19,7 +19,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # Configure types to match semantic-release rules from package.json
-          types: >
+          types: |
             feat
             fix
             docs

--- a/plugins/scaffolder-backend-module-hcl/package.json
+++ b/plugins/scaffolder-backend-module-hcl/package.json
@@ -33,7 +33,7 @@
     "@backstage/config": "^1.2.0",
     "@backstage/plugin-scaffolder-node": "^0.4.10",
     "@backstage/types": "^1.2.0",
-    "@seatgeek/node-hcl": "^1.0.0",
+    "@seatgeek/node-hcl": "^2.0.0",
     "fs-extra": "^11.2.0",
     "zod": "^3.23.8"
   },

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
@@ -57,7 +57,6 @@ describe('createHclMergeAction', () => {
   }
   type = string
 }
-
 `;
 
     const mockCtx = {
@@ -106,7 +105,6 @@ describe('createHclMergeAction', () => {
   }
   type = string
 }
-
 `;
 
     const mockCtx = {
@@ -158,7 +156,6 @@ describe('createHclMergeFilesAction', () => {
   description = "Name to be used on all the resources as identifier"
   type        = string
 }
-
 `;
 
     const aPath = `${mockContext.workspacePath}/${randomBytes(12).toString(
@@ -252,7 +249,6 @@ describe('createHclMergeFilesAction', () => {
   }
 }
 
-
 module "my_module" {
   my_map = {
     "map_a" = {
@@ -269,7 +265,6 @@ module "my_module" {
   var     = local.my_var
   version = "0.0.2"
 }
-
 `;
 
     const aPath = `${mockContext.workspacePath}/${randomBytes(12).toString(

--- a/yarn.lock
+++ b/yarn.lock
@@ -9595,10 +9595,10 @@
   version "0.0.0"
   uid ""
 
-"@seatgeek/node-hcl@^1.0.0":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@seatgeek/node-hcl/-/node-hcl-1.1.1.tgz#13e9a2127a665d8ebedeed31c28e7e4aef6033cc"
-  integrity sha512-pvqj6rzI8sG8/O62vcaj4WL4F6eQSVStGE+97GAONk1a8WLwL4yF68MXo8hfzUSsN+ljUTMoF1qnJECpHpAyLg==
+"@seatgeek/node-hcl@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@seatgeek/node-hcl/-/node-hcl-2.0.0.tgz#ca0d538bbd99b501a5cf20c0c83d913c791109df"
+  integrity sha512-f4B9DFVjAcXlEYQVxsWSvXYKPZLhds4nZQ0fSeqW0c+Q+xdjg296CmtjxOsvOt2tip6q6KtmJPejxXQ2C/gceA==
   dependencies:
     fs-extra "^11.2.0"
 


### PR DESCRIPTION
- feat: Upgrade node-hcl to version that supports merging tfvars files 
BREAKING CHANGE: Upgrade node-hcl to verison 2.0.0, see https://github.com/seatgeek/node-hcl/pull/11
