### PR TITLE
fix(hcl): remove zod dependency and use jsonobject

### DIFF
--- a/plugins/scaffolder-backend-module-hcl/package.json
+++ b/plugins/scaffolder-backend-module-hcl/package.json
@@ -33,8 +33,7 @@
     "@backstage/plugin-scaffolder-node": "^0.4.10",
     "@backstage/types": "^1.2.0",
     "@seatgeek/node-hcl": "^2.0.0",
-    "fs-extra": "^11.2.0",
-    "zod": "^4.0.0"
+    "fs-extra": "^11.2.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.27.0",

--- a/plugins/scaffolder-backend-module-hcl/package.json
+++ b/plugins/scaffolder-backend-module-hcl/package.json
@@ -39,6 +39,7 @@
     "@backstage/cli": "^0.27.0",
     "@testing-library/jest-dom": "^5.10.1",
     "@types/fs-extra": "^11.0.4",
+    "jsonschema": "^1.4.1",
     "msw": "^1.0.0",
     "stream": "^0.0.3"
   },

--- a/plugins/scaffolder-backend-module-hcl/package.json
+++ b/plugins/scaffolder-backend-module-hcl/package.json
@@ -34,7 +34,7 @@
     "@backstage/types": "^1.2.0",
     "@seatgeek/node-hcl": "^2.0.0",
     "fs-extra": "^11.2.0",
-    "zod": "^3.23.8"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.27.0",

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
@@ -326,10 +326,11 @@ describe('schema validation', () => {
   it('schema accepts valid input', () => {
     const action = createHclMergeAction();
     const schema = action.schema?.input;
+    expect(schema).toBeDefined();
 
     const result = validate(
       { aSourceContent: 'foo', bSourceContent: 'bar' },
-      schema,
+      schema as any,
     );
     expect(result.valid).toBe(true);
   });

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
@@ -313,10 +313,11 @@ describe('schema validation', () => {
   it('schema rejects wrong types', () => {
     const action = createHclMergeAction();
     const schema = action.schema?.input;
+    expect(schema).toBeDefined();
 
     const result = validate(
       { aSourceContent: 123, bSourceContent: true },
-      schema,
+      schema as any,
     );
     expect(result.valid).toBe(false);
     expect(result.errors.some(e => e.name === 'type')).toBe(true);

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
@@ -305,9 +305,9 @@ describe('schema validation', () => {
     const result = validate({}, schema);
     expect(result.valid).toBe(false);
     expect(result.errors.length).toBeGreaterThan(0);
-    expect(
-      result.errors.some(e => e.message.includes('aSourceContent')),
-    ).toBe(true);
+    expect(result.errors.some(e => e.message.includes('aSourceContent'))).toBe(
+      true,
+    );
   });
 
   it('schema rejects wrong types', () => {
@@ -319,9 +319,7 @@ describe('schema validation', () => {
       schema,
     );
     expect(result.valid).toBe(false);
-    expect(
-      result.errors.some(e => e.name === 'type'),
-    ).toBe(true);
+    expect(result.errors.some(e => e.name === 'type')).toBe(true);
   });
 
   it('schema accepts valid input', () => {

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
@@ -5,6 +5,7 @@
 import { mockServices } from '@backstage/backend-test-utils';
 import { randomBytes } from 'crypto';
 import { writeFileSync } from 'fs-extra';
+import { validate } from 'jsonschema';
 import { tmpdir } from 'os';
 import { PassThrough } from 'stream';
 import { createHclMergeAction, createHclMergeFilesAction } from './hcl';
@@ -293,5 +294,50 @@ module "my_module" {
 
     expect(mockCtx.output.mock.calls[0][0]).toEqual('hcl');
     expect(mockCtx.output.mock.calls[0][1]).toEqual(expected);
+  });
+});
+
+describe('action schemas are plain JSON Schema (Zod v4 compatibility)', () => {
+  // Backstage's createTemplateAction detects Zod schemas via "safeParseAsync in schema"
+  // and converts them with zod-to-json-schema, which silently breaks under Zod v4
+  // (producing { "type": "string" } instead of an object schema). By passing plain
+  // JSON Schema objects, we bypass this conversion entirely.
+  // See: https://github.com/seatgeek/backstage-plugins/issues/87
+
+  it('schema rejects invalid input (missing required fields)', () => {
+    const action = createHclMergeAction();
+    const schema = action.schema?.input;
+
+    const result = validate({}, schema);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(
+      result.errors.some(e => e.message.includes('aSourceContent')),
+    ).toBe(true);
+  });
+
+  it('schema rejects wrong types', () => {
+    const action = createHclMergeAction();
+    const schema = action.schema?.input;
+
+    const result = validate(
+      { aSourceContent: 123, bSourceContent: true },
+      schema,
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some(e => e.name === 'type'),
+    ).toBe(true);
+  });
+
+  it('schema accepts valid input', () => {
+    const action = createHclMergeAction();
+    const schema = action.schema?.input;
+
+    const result = validate(
+      { aSourceContent: 'foo', bSourceContent: 'bar' },
+      schema,
+    );
+    expect(result.valid).toBe(true);
   });
 });

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
@@ -297,13 +297,7 @@ module "my_module" {
   });
 });
 
-describe('action schemas are plain JSON Schema (Zod v4 compatibility)', () => {
-  // Backstage's createTemplateAction detects Zod schemas via "safeParseAsync in schema"
-  // and converts them with zod-to-json-schema, which silently breaks under Zod v4
-  // (producing { "type": "string" } instead of an object schema). By passing plain
-  // JSON Schema objects, we bypass this conversion entirely.
-  // See: https://github.com/seatgeek/backstage-plugins/issues/87
-
+describe('schema validation', () => {
   it('schema rejects invalid input (missing required fields)', () => {
     const action = createHclMergeAction();
     const schema = action.schema?.input;

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.test.ts
@@ -301,9 +301,9 @@ describe('schema validation', () => {
   it('schema rejects invalid input (missing required fields)', () => {
     const action = createHclMergeAction();
     const schema = action.schema?.input;
+    expect(schema).toBeDefined();
 
-    const result = validate({}, schema);
-    expect(result.valid).toBe(false);
+    const result = validate({}, schema as any);
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.errors.some(e => e.message.includes('aSourceContent'))).toBe(
       true,

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
@@ -78,12 +78,9 @@ const optionsJsonSchema = {
   default: { mergeMapKeys: false },
 };
 
-function defaultOptions(input: {
-  options?: JsonObject;
-}): MergeOptions {
+function defaultOptions(input: { options?: JsonObject }): MergeOptions {
   return {
-    mergeMapKeys:
-      (input.options?.mergeMapKeys as boolean | undefined) ?? false,
+    mergeMapKeys: (input.options?.mergeMapKeys as boolean | undefined) ?? false,
   };
 }
 
@@ -103,8 +100,14 @@ export const createHclMergeAction = (): TemplateAction<{
         type: 'object' as const,
         required: ['aSourceContent', 'bSourceContent'],
         properties: {
-          aSourceContent: { type: 'string', description: 'The HCL content to be merged' },
-          bSourceContent: { type: 'string', description: 'The HCL content to be merged' },
+          aSourceContent: {
+            type: 'string',
+            description: 'The HCL content to be merged',
+          },
+          bSourceContent: {
+            type: 'string',
+            description: 'The HCL content to be merged',
+          },
           options: optionsJsonSchema,
         },
       },
@@ -145,10 +148,19 @@ export const createHclMergeWriteAction = (): TemplateAction<{
         type: 'object' as const,
         required: ['aSourceContent', 'bSourceContent', 'outputPath'],
         properties: {
-          aSourceContent: { type: 'string', description: 'The HCL content to be merged' },
-          bSourceContent: { type: 'string', description: 'The HCL content to be merged' },
+          aSourceContent: {
+            type: 'string',
+            description: 'The HCL content to be merged',
+          },
+          bSourceContent: {
+            type: 'string',
+            description: 'The HCL content to be merged',
+          },
           options: optionsJsonSchema,
-          outputPath: { type: 'string', description: 'The path to write the merged HCL content to' },
+          outputPath: {
+            type: 'string',
+            description: 'The path to write the merged HCL content to',
+          },
         },
       },
     },
@@ -187,8 +199,14 @@ export const createHclMergeFilesAction = (): TemplateAction<{
         type: 'object' as const,
         required: ['aSourcePath', 'bSourcePath'],
         properties: {
-          aSourcePath: { type: 'string', description: 'The path to the HCL file to be merged' },
-          bSourcePath: { type: 'string', description: 'The path to the HCL file to be merged' },
+          aSourcePath: {
+            type: 'string',
+            description: 'The path to the HCL file to be merged',
+          },
+          bSourcePath: {
+            type: 'string',
+            description: 'The path to the HCL file to be merged',
+          },
           options: optionsJsonSchema,
         },
       },
@@ -234,10 +252,19 @@ export const createHclMergeFilesWriteAction = (): TemplateAction<{
         type: 'object' as const,
         required: ['aSourcePath', 'bSourcePath', 'outputPath'],
         properties: {
-          aSourcePath: { type: 'string', description: 'The path to the HCL file to be merged' },
-          bSourcePath: { type: 'string', description: 'The path to the HCL file to be merged' },
+          aSourcePath: {
+            type: 'string',
+            description: 'The path to the HCL file to be merged',
+          },
+          bSourcePath: {
+            type: 'string',
+            description: 'The path to the HCL file to be merged',
+          },
           options: optionsJsonSchema,
-          outputPath: { type: 'string', description: 'The path to write the merged HCL content to' },
+          outputPath: {
+            type: 'string',
+            description: 'The path to write the merged HCL content to',
+          },
         },
       },
     },

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
@@ -113,10 +113,11 @@ export const createHclMergeAction = (): TemplateAction<{
       },
       output: {
         type: 'object' as const,
+        required: ['hcl'],
         properties: {
           hcl: { type: 'string' },
         },
-      },
+      }
     },
     async handler(ctx) {
       const options = defaultOptions(ctx.input);

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
@@ -213,10 +213,11 @@ export const createHclMergeFilesAction = (): TemplateAction<{
       },
       output: {
         type: 'object' as const,
+        required: ['hcl'],
         properties: {
           hcl: { type: 'string' },
         },
-      },
+      }
     },
     async handler(ctx) {
       const options = defaultOptions(ctx.input);

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
@@ -78,6 +78,14 @@ const optionsSchema = z
   .optional()
   .default({ mergeMapKeys: false });
 
+const optionsJsonSchema = {
+  type: 'object' as const,
+  properties: {
+    mergeMapKeys: { type: 'boolean' as const, default: false },
+  },
+  default: { mergeMapKeys: false },
+};
+
 export const createHclMergeAction = (): TemplateAction<{
   aSourceContent: string;
   bSourceContent: string;
@@ -96,10 +104,21 @@ export const createHclMergeAction = (): TemplateAction<{
   }>({
     id: 'hcl:merge',
     schema: {
-      input: inputSchema,
-      output: z.object({
-        hcl: z.string(),
-      }),
+      input: {
+        type: 'object' as const,
+        required: ['aSourceContent', 'bSourceContent'],
+        properties: {
+          aSourceContent: { type: 'string', description: 'The HCL content to be merged' },
+          bSourceContent: { type: 'string', description: 'The HCL content to be merged' },
+          options: optionsJsonSchema,
+        },
+      },
+      output: {
+        type: 'object' as const,
+        properties: {
+          hcl: { type: 'string' },
+        },
+      },
     },
     async handler(ctx) {
       const input = inputSchema.safeParse(ctx.input);
@@ -108,8 +127,6 @@ export const createHclMergeAction = (): TemplateAction<{
           `Invalid input: ${Object.keys(input.error.flatten().fieldErrors)}`,
         );
       }
-
-      ctx.logger.error('output', input.data.options);
 
       const out = await merge(
         input.data.aSourceContent,
@@ -144,7 +161,16 @@ export const createHclMergeWriteAction = (): TemplateAction<{
   }>({
     id: 'hcl:merge:write',
     schema: {
-      input: inputSchema,
+      input: {
+        type: 'object' as const,
+        required: ['aSourceContent', 'bSourceContent', 'outputPath'],
+        properties: {
+          aSourceContent: { type: 'string', description: 'The HCL content to be merged' },
+          bSourceContent: { type: 'string', description: 'The HCL content to be merged' },
+          options: optionsJsonSchema,
+          outputPath: { type: 'string', description: 'The path to write the merged HCL content to' },
+        },
+      },
     },
     async handler(ctx) {
       const input = inputSchema.safeParse(ctx.input);
@@ -189,10 +215,21 @@ export const createHclMergeFilesAction = (): TemplateAction<{
   }>({
     id: 'hcl:merge:files',
     schema: {
-      input: inputSchema,
-      output: z.object({
-        hcl: z.string(),
-      }),
+      input: {
+        type: 'object' as const,
+        required: ['aSourcePath', 'bSourcePath'],
+        properties: {
+          aSourcePath: { type: 'string', description: 'The path to the HCL file to be merged' },
+          bSourcePath: { type: 'string', description: 'The path to the HCL file to be merged' },
+          options: optionsJsonSchema,
+        },
+      },
+      output: {
+        type: 'object' as const,
+        properties: {
+          hcl: { type: 'string' },
+        },
+      },
     },
     async handler(ctx) {
       const input = inputSchema.safeParse(ctx.input);
@@ -241,7 +278,16 @@ export const createHclMergeFilesWriteAction = (): TemplateAction<{
   }>({
     id: 'hcl:merge:files:write',
     schema: {
-      input: inputSchema,
+      input: {
+        type: 'object' as const,
+        required: ['aSourcePath', 'bSourcePath', 'outputPath'],
+        properties: {
+          aSourcePath: { type: 'string', description: 'The path to the HCL file to be merged' },
+          bSourcePath: { type: 'string', description: 'The path to the HCL file to be merged' },
+          options: optionsJsonSchema,
+          outputPath: { type: 'string', description: 'The path to write the merged HCL content to' },
+        },
+      },
     },
     async handler(ctx) {
       const input = inputSchema.safeParse(ctx.input);

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
@@ -7,12 +7,11 @@ import {
   TemplateAction,
   createTemplateAction,
 } from '@backstage/plugin-scaffolder-node';
-import { JsonObject, JsonValue } from '@backstage/types';
+import { JsonObject } from '@backstage/types';
 import { MergeOptions, merge } from '@seatgeek/node-hcl';
 
 import { ensureDirSync, readFileSync, writeFileSync } from 'fs-extra';
 import { dirname } from 'path';
-import { z } from 'zod';
 
 async function readFileSafe(path: string): Promise<string> {
   try {
@@ -71,13 +70,6 @@ async function mergeFilesWrite(
   }
 }
 
-const optionsSchema = z
-  .object({
-    mergeMapKeys: z.boolean().optional().default(false),
-  })
-  .optional()
-  .default({ mergeMapKeys: false });
-
 const optionsJsonSchema = {
   type: 'object' as const,
   properties: {
@@ -86,21 +78,24 @@ const optionsJsonSchema = {
   default: { mergeMapKeys: false },
 };
 
+function defaultOptions(input: {
+  options?: JsonObject;
+}): MergeOptions {
+  return {
+    mergeMapKeys:
+      (input.options?.mergeMapKeys as boolean | undefined) ?? false,
+  };
+}
+
 export const createHclMergeAction = (): TemplateAction<{
   aSourceContent: string;
   bSourceContent: string;
   options: JsonObject | undefined;
 }> => {
-  const inputSchema = z.object({
-    aSourceContent: z.string().describe('The HCL content to be merged'),
-    bSourceContent: z.string().describe('The HCL content to be merged'),
-    options: optionsSchema,
-  });
-
   return createTemplateAction<{
     aSourceContent: string;
     bSourceContent: string;
-    options: JsonValue | undefined;
+    options: JsonObject | undefined;
   }>({
     id: 'hcl:merge',
     schema: {
@@ -121,17 +116,11 @@ export const createHclMergeAction = (): TemplateAction<{
       },
     },
     async handler(ctx) {
-      const input = inputSchema.safeParse(ctx.input);
-      if (!input.success) {
-        throw new Error(
-          `Invalid input: ${Object.keys(input.error.flatten().fieldErrors)}`,
-        );
-      }
-
+      const options = defaultOptions(ctx.input);
       const out = await merge(
-        input.data.aSourceContent,
-        input.data.bSourceContent,
-        input.data.options,
+        ctx.input.aSourceContent,
+        ctx.input.bSourceContent,
+        options,
       );
       ctx.output('hcl', out);
     },
@@ -144,19 +133,10 @@ export const createHclMergeWriteAction = (): TemplateAction<{
   options: JsonObject | undefined;
   outputPath: string;
 }> => {
-  const inputSchema = z.object({
-    aSourceContent: z.string().describe('The HCL content to be merged'),
-    bSourceContent: z.string().describe('The HCL content to be merged'),
-    options: optionsSchema,
-    outputPath: z
-      .string()
-      .describe('The path to write the merged HCL content to'),
-  });
-
   return createTemplateAction<{
     aSourceContent: string;
     bSourceContent: string;
-    options: JsonValue | undefined;
+    options: JsonObject | undefined;
     outputPath: string;
   }>({
     id: 'hcl:merge:write',
@@ -173,24 +153,18 @@ export const createHclMergeWriteAction = (): TemplateAction<{
       },
     },
     async handler(ctx) {
-      const input = inputSchema.safeParse(ctx.input);
-      if (!input.success) {
-        throw new Error(
-          `Invalid input: ${Object.keys(input.error.flatten().fieldErrors)}`,
-        );
-      }
-
+      const options = defaultOptions(ctx.input);
       const outPath = resolveSafeChildPath(
         ctx.workspacePath,
-        input.data.outputPath,
+        ctx.input.outputPath,
       );
 
       ensureDirSync(dirname(outPath));
 
       await mergeWrite(
-        input.data.aSourceContent,
-        input.data.bSourceContent,
-        input.data.options,
+        ctx.input.aSourceContent,
+        ctx.input.bSourceContent,
+        options,
         outPath,
       );
     },
@@ -202,12 +176,6 @@ export const createHclMergeFilesAction = (): TemplateAction<{
   bSourcePath: string;
   options: JsonObject | undefined;
 }> => {
-  const inputSchema = z.object({
-    aSourcePath: z.string().describe('The path to the HCL file to be merged'),
-    bSourcePath: z.string().describe('The path to the HCL file to be merged'),
-    options: optionsSchema,
-  });
-
   return createTemplateAction<{
     aSourcePath: string;
     bSourcePath: string;
@@ -232,22 +200,15 @@ export const createHclMergeFilesAction = (): TemplateAction<{
       },
     },
     async handler(ctx) {
-      const input = inputSchema.safeParse(ctx.input);
-      if (!input.success) {
-        throw new Error(
-          `Invalid input: ${Object.keys(input.error.flatten().fieldErrors)}`,
-        );
-      }
-
+      const options = defaultOptions(ctx.input);
       const aPath = resolveSafeChildPath(
         ctx.workspacePath,
-        input.data.aSourcePath,
+        ctx.input.aSourcePath,
       );
       const bPath = resolveSafeChildPath(
         ctx.workspacePath,
-        input.data.bSourcePath,
+        ctx.input.bSourcePath,
       );
-      const options = input.data.options;
 
       const out = await mergeFiles(aPath, bPath, options);
       ctx.output('hcl', out);
@@ -261,15 +222,6 @@ export const createHclMergeFilesWriteAction = (): TemplateAction<{
   options: JsonObject | undefined;
   outputPath: string;
 }> => {
-  const inputSchema = z.object({
-    aSourcePath: z.string().describe('The path to the HCL file to be merged'),
-    bSourcePath: z.string().describe('The path to the HCL file to be merged'),
-    options: optionsSchema,
-    outputPath: z
-      .string()
-      .describe('The path to write the merged HCL content to'),
-  });
-
   return createTemplateAction<{
     aSourcePath: string;
     bSourcePath: string;
@@ -290,26 +242,19 @@ export const createHclMergeFilesWriteAction = (): TemplateAction<{
       },
     },
     async handler(ctx) {
-      const input = inputSchema.safeParse(ctx.input);
-      if (!input.success) {
-        throw new Error(
-          `Invalid input: ${Object.keys(input.error.flatten().fieldErrors)}`,
-        );
-      }
-
+      const options = defaultOptions(ctx.input);
       const aPath = resolveSafeChildPath(
         ctx.workspacePath,
-        input.data.aSourcePath,
+        ctx.input.aSourcePath,
       );
       const bPath = resolveSafeChildPath(
         ctx.workspacePath,
-        input.data.bSourcePath,
+        ctx.input.bSourcePath,
       );
       const outPath = resolveSafeChildPath(
         ctx.workspacePath,
-        input.data.outputPath,
+        ctx.input.outputPath,
       );
-      const options = input.data.options;
 
       ensureDirSync(dirname(outPath));
 

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
@@ -79,8 +79,9 @@ const optionsJsonSchema = {
 };
 
 function defaultOptions(input: { options?: JsonObject }): MergeOptions {
+  const mergeMapKeys = input.options?.mergeMapKeys;
   return {
-    mergeMapKeys: (input.options?.mergeMapKeys as boolean | undefined) ?? false,
+    mergeMapKeys: typeof mergeMapKeys === 'boolean' ? mergeMapKeys : false,
   };
 }
 

--- a/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
+++ b/plugins/scaffolder-backend-module-hcl/src/actions/hcl/hcl.ts
@@ -117,7 +117,7 @@ export const createHclMergeAction = (): TemplateAction<{
         properties: {
           hcl: { type: 'string' },
         },
-      }
+      },
     },
     async handler(ctx) {
       const options = defaultOptions(ctx.input);
@@ -217,7 +217,7 @@ export const createHclMergeFilesAction = (): TemplateAction<{
         properties: {
           hcl: { type: 'string' },
         },
-      }
+      },
     },
     async handler(ctx) {
       const options = defaultOptions(ctx.input);

--- a/yarn.lock
+++ b/yarn.lock
@@ -21153,6 +21153,11 @@ jsonschema@^1.2.6:
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
   integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==
 
+jsonschema@^1.4.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.5.0.tgz#f6aceb1ab9123563dd901d05f81f9d4883d3b7d8"
+  integrity sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==
+
 jsonwebtoken@^9.0.0, jsonwebtoken@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz#65ff91f4abef1784697d40952bb1998c504caaf3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30746,10 +30746,10 @@ zod@^3.22.4:
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
   integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==
 
-zod@^3.23.8:
-  version "3.23.8"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
-  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
+zod@^4.0.0:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==
 
 zwitch@^2.0.0:
   version "2.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30746,11 +30746,6 @@ zod@^3.22.4:
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
   integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==
 
-zod@^4.0.0:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
-  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==
-
 zwitch@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"


### PR DESCRIPTION
Related to issue https://github.com/seatgeek/backstage-plugins/issues/87.

Rather than fixing zod version incompatibility, we should just remove the zod dependency entirely because we were actually validating the schema twice - once with zod and once with Backstage's built in schema validation. So instead we will just use a plain json schema object.